### PR TITLE
[CWC-80] Documentation: business overview, AGENTS, and frontend spec suite

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,64 @@
+# AGENTS.md — cvc-angular (staff web app)
+
+Instructions for **AI coding agents** and developers working in this repository.
+
+## Product context
+
+Business-oriented overview: [`docs/PROJECT_OVERVIEW.md`](docs/PROJECT_OVERVIEW.md).  
+Technical specs: [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md), [`docs/FRONTEND_SPEC.md`](docs/FRONTEND_SPEC.md), [`docs/API_CONTRACT.md`](docs/API_CONTRACT.md), [`docs/DOMAIN_MODEL.md`](docs/DOMAIN_MODEL.md), [`docs/SECURITY_NOTES.md`](docs/SECURITY_NOTES.md), [`docs/OPERATIONS.md`](docs/OPERATIONS.md), [`docs/adr/`](docs/adr/).
+
+**Sibling API repo:** `nest-server` — canonical HTTP contract and OpenAPI live there (`docs/API_CONTRACT.md`, `docs/openapi/`).
+
+## Stack
+
+- Angular **19**, **standalone** components, `provideRouter`, `provideHttpClient`
+- **PrimeNG** 19 with **Aura** preset
+- **ECharts** for reports charts
+- RxJS 7
+
+## Setup
+
+```bash
+npm install
+npm start
+```
+
+App defaults to `http://localhost:4200/`. Point the API at your backend by editing `src/environments/environment.ts` → **`baseUrl`** (must include `/api/v1` suffix).
+
+## Commands
+
+| Command | Purpose |
+|--------|---------|
+| `npm start` / `ng serve` | Dev server |
+| `npm run build` | Production build (`dist/`) |
+| `npm test` | Unit tests (Karma) |
+
+## Layout
+
+| Path | Role |
+|------|------|
+| `src/app/app.config.ts` | App providers (router, HttpClient, PrimeNG, guards) |
+| `src/app/app-routing.ts` | Top-level routes, lazy feature modules |
+| `src/app/core/` | Shell: layout, guards, auth service, shared layout services |
+| `src/app/modules/` | Feature areas: `dashboard`, `product`, `customers`, `order`, `order-source`, `reports` |
+| `src/app/shared/` | `ApiService`, reusable UI (charts, dialogs, pipes) |
+| `src/app/root-components/` | Login (and register component exists but is **not** routed) |
+| `src/environments/` | `baseUrl` and environment flags |
+
+## Conventions
+
+- **HTTP:** Use **`ApiService`** (`httpGet` / `httpPost` / `httpPut` / `httpDelete`) so `baseUrl` and **`Authorization: Bearer`** from `localStorage` are applied.
+- **Paths:** Prefer **`ApiPaths`** enum for route segments.
+- **Responses:** Backend wraps successes in **`payload`** (see `GenericResponseDto` on API). Client code often uses **`response?.data ?? response?.payload`** — keep parsing consistent when touching services.
+- **Auth:** `AuthGuard` checks `localStorage` key **`token`**; `AuthService` also stores **`user`** as JSON.
+- **Change detection:** Prefer **`ChangeDetectionStrategy.OnPush`** where already used; align with existing patterns in the file you edit.
+
+## Testing and quality
+
+- Run **`npm run build`** before considering UI work complete (catches template/type issues).
+- Match existing **ESLint** rules for the project.
+
+## References
+
+- Deploy: [`docs/DEPLOYMENT_SETUP.md`](docs/DEPLOYMENT_SETUP.md)
+- API details: sibling repo `nest-server/docs/API_CONTRACT.md`

--- a/README.md
+++ b/README.md
@@ -1,27 +1,31 @@
-# CvcWeb
+# CWC — Staff web app (Angular)
 
-This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 15.0.3.
+Internal **Customize With Class** operator UI: products, customers, orders, order sources, and reports.
 
-## Development server
+## Quick start
 
-Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The application will automatically reload if you change any of the source files.
+```bash
+npm install
+npm start
+```
 
-## Code scaffolding
+Open `http://localhost:4200/`. Set the API URL in **`src/environments/environment.ts`** (`baseUrl` must include `/api/v1`).
 
-Run `ng generate component component-name` to generate a new component. You can also use `ng generate directive|pipe|service|class|guard|interface|enum|module`.
+## Documentation
+
+| Doc | Purpose |
+|-----|---------|
+| [`AGENTS.md`](AGENTS.md) | Setup, commands, layout — **start here for devs & AI agents** |
+| [`docs/PROJECT_OVERVIEW.md`](docs/PROJECT_OVERVIEW.md) | Business context |
+| [`docs/FRONTEND_SPEC.md`](docs/FRONTEND_SPEC.md) | Routing, auth, HTTP, features |
+| [`docs/DEPLOYMENT_SETUP.md`](docs/DEPLOYMENT_SETUP.md) | Deployment |
+
+**API repo:** `nest-server` (sibling) — REST contract and OpenAPI live there.
 
 ## Build
 
-Run `ng build` to build the project. The build artifacts will be stored in the `dist/` directory.
+```bash
+npm run build
+```
 
-## Running unit tests
-
-Run `ng test` to execute the unit tests via [Karma](https://karma-runner.github.io).
-
-## Running end-to-end tests
-
-Run `ng e2e` to execute the end-to-end tests via a platform of your choice. To use this command, you need to first add a package that implements end-to-end testing capabilities.
-
-## Further help
-
-To get more help on the Angular CLI use `ng help` or go check out the [Angular CLI Overview and Command Reference](https://angular.io/cli) page.
+This project was generated with [Angular CLI](https://github.com/angular/angular-cli); see Angular docs for `ng generate` and testing options.

--- a/docs/API_CONTRACT.md
+++ b/docs/API_CONTRACT.md
@@ -1,0 +1,26 @@
+# API contract — cvc-angular (integration view)
+
+This app is a **client** of the Nest API. The **authoritative** contract documentation lives in the **backend repo**.
+
+## Canonical references (nest-server)
+
+| Resource | Location |
+|----------|----------|
+| Full HTTP contract (envelope, pagination, public routes) | `nest-server/docs/API_CONTRACT.md` |
+| OpenAPI YAML (envelope + shared schemas) | `nest-server/docs/openapi/openapi.yaml` |
+| OpenAPI generation / JSON snapshot | `nest-server/docs/openapi/README.md` |
+| Live Swagger UI | `{API_ORIGIN}/api` (e.g. `http://localhost:3000/api`) |
+| Live OpenAPI JSON | `{API_ORIGIN}/api-json` |
+
+## How this app calls the API
+
+- **Base URL:** `environment.baseUrl` in `src/environments/environment.ts` — must end with **`/api/v1`**.
+- **Auth header:** `ApiService` adds `Authorization: Bearer <token>` when `localStorage.getItem('token')` is set.
+- **Success bodies:** Prefer reading **`response.payload`**; many services also accept **`response.data`** for compatibility with the backend interceptor (`GenericResponseDto`).
+
+## Client-specific notes
+
+- **Login:** `POST .../auth/login` via `AuthService.signIn`; session persisted with **`token`** and **`user`** keys in `localStorage`.
+- **File uploads:** Use `httpPost` with `isFormData = true` so `Content-Type` is not forced to JSON.
+
+Before changing response handling, read **`nest-server/docs/adr/0003-http-response-envelope-via-interceptor.md`**.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,52 @@
+# Architecture — cvc-angular
+
+**Sibling API repo:** `nest-server` — see `docs/ARCHITECTURE.md` there for persistence and HTTP services.
+
+## System context
+
+```mermaid
+flowchart LR
+  subgraph browser [Staff browser]
+    SPA[Angular SPA]
+  end
+  subgraph api [nest-server]
+    REST[REST API /api/v1]
+  end
+  subgraph assets [External]
+    CDN[Cloudinary images URLs]
+  end
+  SPA -->|HTTPS + JWT| REST
+  SPA --> CDN
+```
+
+This app is a **single-page application** for **internal staff**. It does not implement server-side rendering for business data; all domain operations go through the **Nest API**.
+
+## Front-end container
+
+| Piece | Responsibility |
+|-------|----------------|
+| **Angular router** | Lazy-loaded feature modules under `LayoutComponent` |
+| **`AuthGuard`** | Requires `localStorage` token; else redirect `/login` |
+| **`ApiService`** | Base URL + JSON + Bearer token |
+| **PrimeNG + layout** | Sakai-style shell: sidebar, topbar, content (`core/layout/`) |
+
+## Feature modules (lazy)
+
+| Route prefix | Module folder | Purpose |
+|--------------|---------------|---------|
+| `/dashboard` | `modules/dashboard` | Landing stats |
+| `/products` | `modules/product` | Catalog CRUD |
+| `/customers` | `modules/customers` | Customer CRUD |
+| `/orders` | `modules/order` | List, create/edit wizard (`CreateOrderV2Component`) |
+| `/order-sources` | `modules/order-source` | Sales channel configuration |
+| `/reports` | `modules/reports` | Charts and report views |
+
+## Cross-cutting UI concerns
+
+- **Scroll behavior:** `LayoutComponent` toggles `layout-scrollable` for long pages (dashboard, reports, order create/edit) so flex tables work elsewhere.
+- **Dialogs:** `DialogService` (PrimeNG dynamic dialog) registered in `app.config.ts`.
+- **Static data:** Large JSON datasets (e.g. cities) under `src/assets/data/`.
+
+## Related decisions
+
+See [`docs/adr/`](adr/) for UI-related ADRs (standalone structure, API client conventions).

--- a/docs/DOMAIN_MODEL.md
+++ b/docs/DOMAIN_MODEL.md
@@ -1,0 +1,19 @@
+# Domain model — cvc-angular (summary)
+
+The **system of record** for entities is the **API and PostgreSQL** in `nest-server`. This file gives **UI-facing** context only; keep it aligned with backend changes.
+
+## Authoritative spec
+
+**`nest-server/docs/DOMAIN_MODEL.md`** — tables, relationships, enums, and invariants.
+
+## Concepts the UI must respect
+
+- **Customer:** Person placing orders; includes **province** (used in reports).
+- **Product:** Catalog item with cost, weight, optional image URL.
+- **Order:** Header (amount, payment method, description, status, dates, weight) + **line items** with **per-line** `color` and `customizeName`.
+- **Order source:** Channel (e.g. Instagram, Facebook, web); orders reference **one or more** sources for attribution.
+- **Order status:** Lifecycle includes pending → vendor → dispatched → delivered (and returned).
+
+## Angular models
+
+Feature modules define TypeScript models (e.g. `modules/order/models/order.model.ts`) that map API JSON into classes. When DTOs change on the server, update **models** and **forms** in the same PR (or follow-up) to avoid silent drift.

--- a/docs/FRONTEND_SPEC.md
+++ b/docs/FRONTEND_SPEC.md
@@ -1,0 +1,65 @@
+# Frontend specification — cvc-angular
+
+Detailed **UI and client** behavior for contributors and coding agents.
+
+## Application bootstrap
+
+- **`src/main.ts`** bootstraps `App` with `appConfig` from **`src/app/app.config.ts`**.
+- **Router:** `appRoutes` from **`src/app/app-routing.ts`** — `withPreloading(NoPreloading)`.
+- **Global providers:** `provideHttpClient`, `provideAnimations`, `providePrimeNG` (Aura), `AuthGuard`, `MessageService`, `DialogService`.
+
+## Routing
+
+| URL | Guard | Notes |
+|-----|-------|--------|
+| `''` (children) | `AuthGuard` | Wrapped in `LayoutComponent` |
+| `/dashboard` | ✓ | Lazy `dashboard.routes` |
+| `/products` | ✓ | Lazy `product.routes` |
+| `/customers` | ✓ | Lazy `customers.routes` |
+| `/orders` | ✓ | Lazy `order.routes` — list at `''`, create `/create`, edit `/:orderId/edit` |
+| `/order-sources` | ✓ | Lazy `order-source.routes` |
+| `/reports` | ✓ | Lazy `reports.routes` |
+| `/login` | — | `LoginComponent` |
+| `**` | — | Redirect to `/login` |
+
+**Unused route asset:** `root-components/register/` exists but **`RegisterComponent` is not registered** in `app-routing.ts`.
+
+## Authentication
+
+- **`AuthService`** (`core/services/auth.service.ts`): `signIn`, `setSession`, `clearSession`, `getStoredToken`, `getStoredUser`.
+- **`AuthGuard`** (`core/guards/auth.guard.ts`): redirects to `/login` if no token.
+- Login response normalized from `response.payload` or `response.data` into **`LoginResponse`** model.
+
+## HTTP layer
+
+- **`ApiService`** (`shared/services/api.service.ts`): builds URLs with `environment.baseUrl`, attaches Bearer token, supports `FormData` via `isFormData` flag.
+- **`ApiPaths`** (`shared/enums/api-paths.ts`): `/products`, `/customers`, `/orders`, `/auth`, `/reports`, `/reports/dashboard/stats`, `/order-sources`.
+
+Domain services (e.g. **`modules/order/services/order.service.ts`**) wrap `ApiService` and map responses into **model classes**.
+
+## Layout and navigation
+
+- **`LayoutComponent`:** sidebar, topbar, footer, menu; `LayoutService` for UI state (menu mode, dark/light).
+- **`MenuComponent`:** static menu model linking to dashboard, products, customers, orders, order sources, reports.
+
+## Feature highlights
+
+| Area | Location | Notes |
+|------|----------|--------|
+| Orders | `modules/order/` | **CreateOrderV2Component** is primary create/edit UX; subcomponents for product search, cards, summary, order info form |
+| Reports | `modules/reports/` | Data services + ECharts wrappers in `shared/components/` |
+| Products | `modules/product/` | List, create, edit |
+| Customers | `modules/customers/` | Create, edit |
+
+## Styling
+
+- Global styles: **`src/styles.scss`**
+- Layout SCSS under **`src/assets/layout/styles/`**
+- PrimeFlex utility classes used alongside PrimeNG components
+
+## Conventions for changes
+
+- Prefer **standalone** `imports` on components already using that style.
+- Use **`inject()`** for DI in new code where neighboring files do.
+- Reuse **`ApiService`**; do not hardcode API origins in components.
+- After API contract changes, update **`nest-server`** docs and **`docs/API_CONTRACT.md`** pointers, then adjust models and services here.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,0 +1,31 @@
+# Operations — cvc-angular
+
+## Environment configuration
+
+Edit **`src/environments/environment.ts`** (and **`environment.prod.ts`** for production builds):
+
+| Field | Purpose |
+|-------|---------|
+| `production` | Angular build mode flag |
+| `baseUrl` | Full REST prefix including **`/api/v1`** |
+
+Example local value: `http://localhost:3000/api/v1`.
+
+The checked-in default may point at a **hosted** API; override for local development.
+
+## Commands
+
+```bash
+npm install
+npm start          # dev server, default http://localhost:4200
+npm run build      # output in dist/
+npm test
+```
+
+## Deployment
+
+See **[`DEPLOYMENT_SETUP.md`](DEPLOYMENT_SETUP.md)** in this folder.
+
+## Backend dependency
+
+The UI expects the **nest-server** API to be running and reachable at `baseUrl`. API env vars, migrations, and health checks: **`nest-server/docs/OPERATIONS.md`**.

--- a/docs/PROJECT_OVERVIEW.md
+++ b/docs/PROJECT_OVERVIEW.md
@@ -1,0 +1,148 @@
+# Customize With Class (CWC) — Project overview
+
+**Purpose of this document:** Explain **why this product exists**, **who it helps**, and **what it does** in business terms. A short **technical appendix** at the end supports engineers and AI assistants who need to navigate the codebase.
+
+**Audience:** Founders, operators, product-minded contributors, and implementers.
+
+**Scope:** The product spans two repositories: the **staff web app** (`cvc-angular`, package name `cvc-web`) and the **API** (`nest-server`). Keep this file aligned with `nest-server/docs/PROJECT_OVERVIEW.md` (same content aside from the repo note below).
+
+**This copy:** Frontend repo. **Sibling doc:** `nest-server/docs/PROJECT_OVERVIEW.md`.
+
+**Last reviewed:** 2026-04-12.
+
+---
+
+## 1. What this product is
+
+**Customize With Class** is an internal **order and operations hub** for a small business that sells **made-to-order or personalized physical goods**—for example items where each line might need a specific color, label, engraving, or other customization.
+
+It is **not** a consumer shopping cart. It is the **team’s system of record**: one place to capture orders, tie them to real customers and products, know where each order came from (social, web, etc.), move work through fulfillment stages, and see **simple business reports** (volume, geography, channels, top products).
+
+---
+
+## 2. The business problem
+
+Small shops taking customized orders often struggle because:
+
+- **Details live in scattered places**—DMs, spreadsheets, notebooks—so it is easy to lose specifications or duplicate effort.
+- **Every order is different**; generic retail tools do not model **per-line customization** (colors, names, variants) well.
+- **Knowing what to make and ship** depends on clear **order status** and history; without it, the team chases updates manually.
+- **Growth is hard to see** when the owner cannot quickly answer: *Where do orders come from? What sells? Which regions order most?*
+
+Without a dedicated system, the business risks mistakes, slower fulfillment, and weak visibility into what is actually working.
+
+---
+
+## 3. The solution (why this product exists)
+
+CWC gives the business a **single, structured workflow**:
+
+1. **Define what you sell** (products, costs, weights, images) so the team speaks one language about the catalog.
+2. **Know your buyers** (customers with contact and location) so orders are tied to real people and addresses.
+3. **Record each order once** with line-level customization, payment method, totals, and weight—so production and dispatch have a clear spec.
+4. **Tag where the sale originated** (e.g. Instagram, Facebook, web) so marketing and effort can be tied to results.
+5. **Track the order through its life** (pending → with vendor → dispatched → delivered, with room for returns) so everyone sees the same state.
+6. **Glance at the business** via a dashboard and reports instead of reconstructing numbers by hand.
+
+The product exists to **reduce operational chaos**, **cut errors on custom work**, and **make informal channel sales measurable**.
+
+---
+
+## 4. Who uses it
+
+| User | Role in the story |
+|------|-------------------|
+| **Business operators / staff** | Day-to-day users: log in, manage catalog and customers, create and edit orders, update status, review reports. |
+| **Owner / manager** | Same app; cares especially about overview stats, sources, and product performance. |
+| **End customers** | They do not use this app directly; their orders and details are **captured and managed here** by the team. |
+
+Access is **staff-only** (sign-in); the app assumes a trusted internal team.
+
+---
+
+## 5. How it helps (outcomes)
+
+- **Fewer mistakes on custom orders** because specifications (per line) and customer details live with the order.
+- **Faster answers** to “What’s the status?” and “What did they order?” without digging through messages.
+- **Clearer picture of demand** by **order source** (which channels drive sales).
+- **Better geographic and product insight** through reports (e.g. orders by region, over time, top products).
+- **One workflow** from intake to fulfillment tracking, sized for a **small team** without enterprise complexity.
+
+---
+
+## 6. Core capabilities (the system as a whole)
+
+These are the **main things the product does** for the business, independent of how the code is split.
+
+1. **Secure staff access** — Team members sign in; work happens inside a protected workspace.
+2. **Product catalog** — Maintain products (including cost, weight, descriptions, and visuals) so orders always reference the same items.
+3. **Customer records** — Store buyers with contact information and location (including province/region) for shipping, support, and reporting.
+4. **Order management** — Create and edit orders with:
+   - linked customer,
+   - multiple line items from the catalog,
+   - **per-line customization** (e.g. color, personalized name/text),
+   - payment method, amounts, optional total weight,
+   - **order date** and free-text description for extra notes.
+5. **Order sources** — Configure and assign **channels** (e.g. Instagram, Facebook, web) to orders so the business can see **where sales originate**.
+6. **Order status** — Move orders through stages that match how the shop works (e.g. pending, with vendor, dispatched, delivered; returns when needed).
+7. **Dashboard & reports** — High-level stats plus deeper views (orders by period, by source, by province; product performance) to support decisions.
+8. **Supporting assets** — Ability to attach/upload images and documents where the product needs them (e.g. product imagery, files relevant to orders).
+
+Together, these capabilities form the **operating backbone** for a small customized-goods business.
+
+---
+
+## 7. Typical order journey (business view)
+
+```mermaid
+flowchart LR
+  A[Inquiry or sale on a channel] --> B[Staff creates order in CWC]
+  B --> C[Order linked to customer and products]
+  C --> D[Customization captured per line]
+  D --> E[Source tagged e.g. Instagram]
+  E --> F[Status updated through fulfillment]
+  F --> G[Delivered or returned]
+  G --> H[Reports reflect volume and patterns]
+```
+
+This is the **intended story** the software supports—not a mandatory rigid process, but the mental model the features reinforce.
+
+---
+
+## 8. What the product is not (scope)
+
+- **Not** a public e-commerce storefront for shoppers.
+- **Not** payment processing or accounting software (it records **payment method** and amounts as the business enters them; it does not replace a bank or accounting tool).
+- **Not** inventory or manufacturing execution at scale—though **weight** and **quantities** support operational awareness.
+
+Keeping this boundary clear helps stakeholders set the right expectations.
+
+---
+
+## Appendix A — Technical snapshot (for orientation)
+
+| Piece | Repository | Role |
+|-------|------------|------|
+| Staff web UI | `cvc-angular` | Angular app: dashboard, products, customers, orders, order sources, reports, login. |
+| API & database | `nest-server` | NestJS REST API, PostgreSQL, file storage integration for uploads. |
+
+**Stack (high level):** Angular 19 + PrimeNG on the frontend; NestJS 9 + TypeORM + PostgreSQL on the backend; JWT-based staff authentication.
+
+**Local development:** Run API and UI together; point the Angular `environment.baseUrl` at the running API.
+
+**Further technical detail:** OpenAPI/Swagger is served from the API when running; a Postman collection lives under `nest-server/docs/postman_collection`. Frontend deployment notes: `cvc-angular/docs/DEPLOYMENT_SETUP.md`.
+
+**Specification suite (both repos, Option A layout):** Root **`AGENTS.md`**, plus **`docs/ARCHITECTURE.md`**, **`docs/API_CONTRACT.md`**, **`docs/DOMAIN_MODEL.md`**, **`docs/OPERATIONS.md`**, **`docs/SECURITY_NOTES.md`**, **`docs/adr/`**, and **`docs/openapi/`** (API repo). The Angular repo also has **`docs/FRONTEND_SPEC.md`**.
+
+---
+
+## Appendix B — For implementers & AI assistants
+
+- **Start here:** Repo root **`AGENTS.md`**, then the **`docs/`** files above; keep **`PROJECT_OVERVIEW.md`** for business context only.
+- **Where to start in code:** Backend `src/app.module.ts`, `src/main.ts`; frontend `src/app/app-routing.ts`, `src/app/app.config.ts`. Order flows live under `nest-server/src/modules/order/` and `cvc-angular/src/app/modules/order/`.
+- **Database changes:** Use TypeORM migrations; schema sync is not enabled for production safety.
+- **API responses:** Success payloads are wrapped consistently (`payload` / `metadata`); client services often accept both `data` and `payload`—keep that contract coherent when changing either side.
+- **Public vs authenticated routes:** Some endpoints are intentionally public (e.g. health, login); changing that surface is security-sensitive.
+- **Maintenance:** When you add a **user-visible capability**, update the **Core capabilities** and **Order journey** sections here in **business language**; put file-level detail in code comments or API docs rather than bloating this overview.
+
+When business positioning or target users change, revise sections 1–8 first so this file stays the **context anchor** for the project.

--- a/docs/SECURITY_NOTES.md
+++ b/docs/SECURITY_NOTES.md
@@ -1,0 +1,27 @@
+# Security notes — cvc-angular
+
+Browser-facing considerations for the **staff SPA**. Server-side exposure: **`nest-server/docs/SECURITY_NOTES.md`**.
+
+## Session storage
+
+- **JWT** is stored in **`localStorage`** under the key **`token`** (`AuthService`).
+- **User profile** snapshot is stored as JSON under **`user`** for display convenience.
+
+**Implications:** Any script running on the origin can read these values (XSS risk). Keep dependencies updated and avoid injecting untrusted HTML.
+
+## Transport
+
+- Use **HTTPS** in production so tokens and PII are not sent in clear text.
+- Ensure `environment.baseUrl` uses **https:** against production APIs.
+
+## Authentication gate
+
+- **`AuthGuard`** only checks **presence** of a token, not expiry or signature validity. Expired tokens may yield **401** from the API until the user logs in again — handle errors in services or interceptors if you add global 401→logout behavior.
+
+## No role-based UI
+
+- The API does not expose fine-grained roles in the current model; the UI does not hide menus by permission. If RBAC is added server-side, mirror it in routing and menu config.
+
+## CORS
+
+- Not configured in this repo; the **API** enables CORS. Coordinate allowed origins with **`nest-server`** when locking down production.

--- a/docs/adr/0001-record-architecture-decisions.md
+++ b/docs/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,17 @@
+# ADR 0001: Record architecture decisions
+
+- **Status:** Accepted
+- **Date:** 2026-04-12
+
+## Context
+
+The SPA will gain features (orders, reports, auth flows). Without a log, UI conventions become tribal knowledge.
+
+## Decision
+
+Maintain **ADRs** under `docs/adr/` for decisions that affect structure, data flow, or integration with the API.
+
+## Consequences
+
+- **Positive:** Frontend and full-stack contributors share explicit rationale.
+- **Negative:** Keep ADRs short; defer API-only decisions to `nest-server/docs/adr/`.

--- a/docs/adr/0002-angular-standalone-feature-modules.md
+++ b/docs/adr/0002-angular-standalone-feature-modules.md
@@ -1,0 +1,21 @@
+# ADR 0002: Angular standalone components and lazy feature modules
+
+- **Status:** Accepted
+- **Date:** 2026-04-12
+
+## Context
+
+Angular 19 encourages **standalone** APIs; the codebase mixes a shell layout with **lazy-loaded** feature routes.
+
+## Decision
+
+Use **standalone** components with explicit `imports` arrays and **`loadChildren`** returning `import().then(m => m.*Routes)` for feature areas (`dashboard`, `product`, `customers`, `order`, `order-source`, `reports`).
+
+## Consequences
+
+- **Positive:** Features are **boundary-separated**; bundle size improves via lazy loading.
+- **Negative:** No single `SharedModule`; shared pieces live under **`shared/`** and are imported per component — follow existing patterns when adding widgets.
+
+## Alternatives considered
+
+- **NgModule-based feature modules:** Older style; inconsistent with current code.

--- a/docs/adr/0003-client-api-layer-and-response-parsing.md
+++ b/docs/adr/0003-client-api-layer-and-response-parsing.md
@@ -1,0 +1,23 @@
+# ADR 0003: Centralized API client and defensive response parsing
+
+- **Status:** Accepted
+- **Date:** 2026-04-12
+
+## Context
+
+All HTTP calls must target the same **base URL** and attach **JWT** consistently. The backend wraps responses in a **generic envelope** (`payload` / `metadata`).
+
+## Decision
+
+- Route HTTP through **`ApiService`** (`shared/services/api.service.ts`).
+- Use **`ApiPaths`** for path segments.
+- In domain services, parse **`response?.data ?? response?.payload`** where both shapes have appeared historically.
+
+## Consequences
+
+- **Positive:** One place to add interceptors (e.g. global 401) later; consistent headers.
+- **Negative:** Defensive `data`/`payload` merge can hide contract drift — prefer tightening the contract in **`nest-server`** and then simplifying clients.
+
+## Related
+
+- Backend: **`nest-server/docs/adr/0003-http-response-envelope-via-interceptor.md`**

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,16 @@
+# Architecture Decision Records (ADR)
+
+Technical decisions specific to the **Angular** client. API and persistence ADRs live in **`nest-server/docs/adr/`**.
+
+## Index
+
+| ADR | Title |
+|-----|--------|
+| [0001](0001-record-architecture-decisions.md) | Record architecture decisions |
+| [0002](0002-angular-standalone-feature-modules.md) | Angular standalone components and feature modules |
+| [0003](0003-client-api-layer-and-response-parsing.md) | Client API layer and response parsing |
+
+## When to add an ADR
+
+- UI architecture, routing, or client–server conventions change in a **durable** way.
+- Prefer **one decision per file**; link to the sibling repo when the decision is shared.

--- a/docs/openapi/README.md
+++ b/docs/openapi/README.md
@@ -1,0 +1,9 @@
+# OpenAPI (reference)
+
+OpenAPI artifacts are **owned by the API repository**.
+
+- **Envelope + shared schemas:** `nest-server/docs/openapi/openapi.yaml`
+- **Generation instructions and JSON snapshot:** `nest-server/docs/openapi/README.md`
+- **Live docs** (when API is running): Swagger at `{API_ORIGIN}/api`, JSON at `{API_ORIGIN}/api-json`
+
+The Angular app does not generate OpenAPI; it **consumes** the API per `docs/API_CONTRACT.md`.


### PR DESCRIPTION
## CWC-80

Adds the mirrored **Option A** documentation layout for the staff Angular app.

### Included
- `docs/PROJECT_OVERVIEW.md` — business context (problem, solution, capabilities, journey)
- Root `AGENTS.md` — setup, commands, layout, conventions for developers and AI assistants
- `docs/ARCHITECTURE.md`, `API_CONTRACT.md` (integration view), `DOMAIN_MODEL.md` (summary), `OPERATIONS.md`, `SECURITY_NOTES.md`
- `docs/FRONTEND_SPEC.md` — routing, auth, HTTP layer, features
- `docs/adr/` — ADRs for standalone modules and API client patterns
- `docs/openapi/README.md` — pointer to backend OpenAPI artifacts
- `README.md` — entry points into the doc set

### Related
- Backend PR: **cwc-nest** repository, branch `cwc-80-documentation-and-specs` (same task).
