### PR TITLE
fix(web): order form totals match line quantities (CWC-82)

### DIFF
--- a/src/app/modules/order/components/create-order-v2/components/order-summary/order-summary.component.html
+++ b/src/app/modules/order/components/create-order-v2/components/order-summary/order-summary.component.html
@@ -11,7 +11,7 @@
           <div class="summary-line__left">
             <span class="summary-line__name">{{ item.product?.name }}</span>
             <span class="summary-line__qty">
-              {{ item.formGroup.get('price')?.value ?? 0 | number }} × {{ item.rowGroups.length }}
+              {{ item.formGroup.get('price')?.value ?? 0 | number }} × {{ totalUnitsForProduct(item) }} units
             </span>
           </div>
           <span class="summary-line__amount">{{ getLineTotal(item) | number }}</span>

--- a/src/app/modules/order/components/create-order-v2/components/order-summary/order-summary.component.ts
+++ b/src/app/modules/order/components/create-order-v2/components/order-summary/order-summary.component.ts
@@ -1,7 +1,6 @@
 import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
 import { DecimalPipe } from '@angular/common';
 import { ButtonModule } from 'primeng/button';
-
 import { OrderProductMapEntry } from '../../../../interfaces/order-product.interface';
 
 @Component({
@@ -20,8 +19,18 @@ export class OrderSummaryComponent {
   save = output<void>();
   cancel = output<void>();
 
+  totalUnitsForProduct(item: OrderProductMapEntry): number {
+    return item.rowGroups.reduce((sum, row) => {
+      const q = Math.max(1, Math.floor(Number(row.get('quantity')?.value) || 1));
+      return sum + q;
+    }, 0);
+  }
+
   getLineTotal(item: OrderProductMapEntry): number {
-    const price = item.formGroup?.get('price')?.value ?? 0;
-    return price * item.rowGroups.length;
+    const price = Number(item.formGroup?.get('price')?.value) || 0;
+    return item.rowGroups.reduce((sum, row) => {
+      const q = Math.max(1, Math.floor(Number(row.get('quantity')?.value) || 1));
+      return sum + price * q;
+    }, 0);
   }
 }

--- a/src/app/modules/order/components/create-order-v2/components/product-card/product-card.component.html
+++ b/src/app/modules/order/components/create-order-v2/components/product-card/product-card.component.html
@@ -13,7 +13,7 @@
         </span>
         <span class="badge badge--qty">
           <i class="pi pi-list"></i>
-          {{ entry.rowGroups.length }} item(s)
+          {{ entry.rowGroups.length }} line(s), {{ totalUnits(entry) }} units
         </span>
         <span class="badge badge--weight">
           <i class="pi pi-inbox"></i>
@@ -54,7 +54,7 @@
         <small class="field-hint">
           <i class="pi pi-info-circle"></i>
           Base cost is <strong>{{ entry.product?.cost | number }}</strong>.
-          Total for {{ entry.rowGroups.length }} item(s):
+          Line total ({{ totalUnits(entry) }} units):
           <strong class="hint-total">{{ getLineTotal(entry) | number }}</strong>
         </small>
       }
@@ -64,6 +64,7 @@
   <div class="product-card__items">
     <div class="items-table-header">
       <span class="items-table-header__num">#</span>
+      <span>Qty</span>
       <span>Customize Name</span>
       <span>Color</span>
       <span></span>
@@ -72,6 +73,18 @@
     @for (rowGroup of entry.rowGroups; track $index) {
       <div class="item-row" [formGroup]="rowGroup" [class.item-row--even]="$index % 2 === 1">
         <span class="item-row__index">{{ $index + 1 }}</span>
+
+        <div class="item-row__field item-row__field--qty">
+          <p-inputNumber
+            formControlName="quantity"
+            [min]="1"
+            [useGrouping]="false"
+            [showButtons]="true"
+            inputStyleClass="w-full"
+            styleClass="w-full"
+            (onBlur)="quantityBlur.emit()"
+          />
+        </div>
 
         <div class="item-row__field">
           <p-floatLabel>

--- a/src/app/modules/order/components/create-order-v2/components/product-card/product-card.component.ts
+++ b/src/app/modules/order/components/create-order-v2/components/product-card/product-card.component.ts
@@ -35,9 +35,20 @@ export class ProductCardComponent {
   removeRow = output<number>();
   addRow = output<void>();
   priceBlur = output<void>();
+  quantityBlur = output<void>();
+
+  totalUnits(entry: OrderProductMapEntry): number {
+    return entry.rowGroups.reduce((sum, row) => {
+      const q = Math.max(1, Math.floor(Number(row.get('quantity')?.value) || 1));
+      return sum + q;
+    }, 0);
+  }
 
   getLineTotal(entry: OrderProductMapEntry): number {
-    const price = entry.formGroup?.get('price')?.value ?? 0;
-    return price * entry.rowGroups.length;
+    const price = Number(entry.formGroup?.get('price')?.value) || 0;
+    return entry.rowGroups.reduce((sum, row) => {
+      const q = Math.max(1, Math.floor(Number(row.get('quantity')?.value) || 1));
+      return sum + price * q;
+    }, 0);
   }
 }

--- a/src/app/modules/order/components/create-order-v2/create-order-v2.component.html
+++ b/src/app/modules/order/components/create-order-v2/create-order-v2.component.html
@@ -32,6 +32,7 @@
           (removeRow)="onRemoveProductRow($event, item.product.name)"
           (addRow)="addOrderProductRow(item.product, true)"
           (priceBlur)="calculateOrderTotalAmount()"
+          (quantityBlur)="calculateOrderTotalAmount()"
         />
       }
 

--- a/src/app/modules/order/components/create-order-v2/create-order-v2.component.ts
+++ b/src/app/modules/order/components/create-order-v2/create-order-v2.component.ts
@@ -158,7 +158,11 @@ export class CreateOrderV2Component implements OnInit {
     Object.keys(productsGroupedByName).forEach((productName: string) => {
       const group = productsGroupedByName[productName];
       group.forEach((orderProduct: OrderProduct) => {
-        this.addOrderProductRow(orderProduct as ProductOrderProduct);
+        this.addOrderProductRow(
+          orderProduct as ProductOrderProduct,
+          false,
+          orderProduct.quantity,
+        );
       });
     });
     this.canShowProductDetailsTable.set(true);
@@ -256,16 +260,22 @@ export class CreateOrderV2Component implements OnInit {
     return this.formBuilder.group({
       price: [product.price ?? null, [Validators.required]],
       rows: this.formBuilder.array(
-        isEmptyRows ? [] : [this.newOrderProductRow(product)],
+        isEmptyRows ? [] : [this.newOrderProductRow(product, {})],
         Validators.required
       ),
     });
   }
 
-  newOrderProductRow(product: ProductOrderProduct, isNew = false): FormGroup {
-    const customizeName = isNew ? '' : (product as OrderProduct).customizeName ?? '';
-    const color = isNew ? '' : (product as OrderProduct).color ?? '';
-    const quantity = this.getOrderProductQuantity(product.name, isNew);
+  newOrderProductRow(
+    product: ProductOrderProduct,
+    options: { isBlankRow?: boolean; quantity?: number } = {},
+  ): FormGroup {
+    const isBlank = options.isBlankRow ?? false;
+    const customizeName = isBlank ? '' : (product as OrderProduct).customizeName ?? '';
+    const color = isBlank ? '' : (product as OrderProduct).color ?? '';
+    const quantity =
+      options.quantity ??
+      (isBlank ? 1 : (product as OrderProduct).quantity ?? 1);
     return this.formBuilder.group({
       productId: [product.id, [Validators.required]],
       color,
@@ -273,7 +283,7 @@ export class CreateOrderV2Component implements OnInit {
       name: product.name,
       cost: product.cost,
       weight: product.weight,
-      quantity,
+      quantity: [quantity, [Validators.required, Validators.min(1)]],
     });
   }
 
@@ -307,10 +317,21 @@ export class CreateOrderV2Component implements OnInit {
     this.refreshOrderProductsMap();
   }
 
-  addOrderProductRow(product: ProductOrderProduct, isNew = false): void {
+  addOrderProductRow(
+    product: ProductOrderProduct,
+    isNewBlankRow = false,
+    explicitQuantity?: number,
+  ): void {
     const productRows = this.getOrderProductRows(product.name);
-    productRows.push(this.newOrderProductRow(product, isNew));
-    this.incrementProductQuantityCount(product.name);
+    const quantity =
+      explicitQuantity ??
+      (isNewBlankRow ? 1 : (product as OrderProduct).quantity ?? 1);
+    productRows.push(
+      this.newOrderProductRow(product, {
+        isBlankRow: isNewBlankRow,
+        quantity,
+      }),
+    );
     this.calculateOrderTotalAmount();
     this.refreshOrderProductsMap();
   }
@@ -318,26 +339,31 @@ export class CreateOrderV2Component implements OnInit {
   onRemoveProductRow(rowIndex: number, productName: string): void {
     const orderProductRows = this.getOrderProductRows(productName);
     orderProductRows.removeAt(rowIndex);
-    this.decrementProductQuantityCount(productName);
     this.calculateOrderTotalAmount();
     this.refreshOrderProductsMap();
   }
 
   calculateOrderTotalAmount(): void {
     let total = 0;
-    Object.keys(this.orderForm.value.orderProducts).forEach((productName: string) => {
-      const orderProducts = this.orderForm.value.orderProducts[productName];
-      const orderProductQuantity = orderProducts.rows?.length;
-      if (orderProducts?.price > 0) {
-        total += orderProducts?.price * orderProductQuantity;
-      }
+    const orderProductsRoot = this.orderForm.value.orderProducts ?? {};
+    Object.keys(orderProductsRoot).forEach((productName: string) => {
+      const bundle = orderProductsRoot[productName];
+      const price = Number(bundle?.price) || 0;
+      const rows = bundle?.rows ?? [];
+      rows.forEach((row: { quantity?: number }) => {
+        const q = Math.max(1, Math.floor(Number(row.quantity) || 1));
+        total += price * q;
+      });
     });
     this.orderTotalAmount.set(total);
   }
 
   getLineTotal(item: { formGroup: FormGroup; rowGroups: FormGroup[] }): number {
-    const price = item.formGroup?.get('price')?.value ?? 0;
-    return price * item.rowGroups.length;
+    const price = Number(item.formGroup?.get('price')?.value) || 0;
+    return item.rowGroups.reduce((sum, row) => {
+      const q = Math.max(1, Math.floor(Number(row.get('quantity')?.value) || 1));
+      return sum + price * q;
+    }, 0);
   }
 
   saveOrder(): void {
@@ -390,14 +416,22 @@ export class CreateOrderV2Component implements OnInit {
   }
 
   buildCreateOrderPayload(): object {
+    const orderItems = this.buildOrderProductsPayload() as Array<{
+      quantity?: number;
+    }>;
+    const totalUnits = orderItems.reduce(
+      (sum, row) =>
+        sum + Math.max(1, Math.floor(Number(row.quantity) || 1)),
+      0,
+    );
     return {
       description: this.orderForm.value.description,
       paymentMethod: this.orderForm.value.paymentMethod?.value,
       amount: this.orderTotalAmount(),
       customerId: this.orderForm.value.selectedCustomer?.id,
-      totalProductQuantity: this.buildOrderProductsPayload()?.length,
+      totalProductQuantity: totalUnits,
       totalWeight: this.getTotalCountByProperty('weight').toString(),
-      orderItems: this.buildOrderProductsPayload(),
+      orderItems,
       orderDate: this.orderForm.value?.orderDate,
       orderSourceIds: this.orderForm.value.selectedOrderSources,
     };
@@ -431,8 +465,11 @@ export class CreateOrderV2Component implements OnInit {
   private getTotalCountByProperty(propertyName: string): number {
     const orderProducts = flatMap(this.orderForm.value?.orderProducts, (value) => value.rows);
     return sumBy(orderProducts, (item) => {
-      const numericWeight = parseFloat(String(item[propertyName]).replace(/[^\d.]/g, ''));
-      return isNaN(numericWeight) ? 0 : numericWeight;
+      const raw = String(item[propertyName] ?? '').replace(/[^\d.]/g, '');
+      const numericWeight = parseFloat(raw);
+      const units = Math.max(1, Math.floor(Number(item.quantity) || 1));
+      const perUnit = isNaN(numericWeight) ? 0 : numericWeight;
+      return perUnit * units;
     });
   }
 
@@ -446,29 +483,6 @@ export class CreateOrderV2Component implements OnInit {
       customizeName: product.customizeName,
       quantity: product.quantity,
     }));
-  }
-
-  private incrementProductQuantityCount(productName: string): void {
-    const orderProductRows = this.getOrderProductRows(productName);
-    const incremented =
-      Number(orderProductRows.controls[0]?.get('quantity')?.value) + 1;
-    for (let i = 0; i < orderProductRows.length; i++) {
-      orderProductRows.controls[i].get('quantity')?.setValue(incremented);
-    }
-  }
-
-  private decrementProductQuantityCount(productName: string): void {
-    const orderProductRows = this.getOrderProductRows(productName);
-    let qty = this.getOrderProductQuantity(productName);
-    qty = qty > 0 ? qty - 1 : 0;
-    for (let i = 0; i < orderProductRows.length; i++) {
-      orderProductRows.controls[i].get('quantity')?.setValue(qty);
-    }
-  }
-
-  private getOrderProductQuantity(productName: string, isNew = false): number {
-    const orderProductRows = this.getOrderProductRows(productName);
-    return isNew ? orderProductRows.length + 1 : orderProductRows?.length ?? 1;
   }
 
   private mapOrderSourcesToNameValue(orderSources: Array<OrderSource>): Array<OrderSource> {

--- a/src/app/modules/order/components/create-order/create-order.component.html
+++ b/src/app/modules/order/components/create-order/create-order.component.html
@@ -88,13 +88,16 @@
                       @if (canShowProductDetailsTable()) {
                         <div class="order-product-table">
                           <div class="grid header-row mt-2">
-                            <div class="col-3 column">
+                            <div class="col-2 column">
                               <h5 class="text-primary">Name</h5>
                             </div>
                             <div class="col-2 column">
                               <h5 class="text-primary">Cost</h5>
                             </div>
-                            <div class="col-3 column">
+                            <div class="col-2 column">
+                              <h5 class="text-primary">Qty</h5>
+                            </div>
+                            <div class="col-2 column">
                               <h5 class="text-primary">Customize Name</h5>
                             </div>
                             <div class="col-2 column">
@@ -103,9 +106,13 @@
                           </div>
                           @for (rowGroup of item.rowGroups; track $index) {
                           <div class="grid">
-                            <div class="col-3 column">{{ item.product?.name }}</div>
+                            <div class="col-2 column">{{ item.product?.name }}</div>
                             <div class="col-2 column">{{ item.product?.cost }}</div>
-                            <div class="col-3" [formGroup]="rowGroup">
+                            <div class="col-2" [formGroup]="rowGroup">
+                              <input type="number" min="1" formControlName="quantity" (blur)="calculateOrderTotalAmount()"
+                                class="text-base text-color surface-overlay p-2 border-1 border-solid surface-border border-round appearance-none outline-none focus:border-primary w-full" />
+                            </div>
+                            <div class="col-2" [formGroup]="rowGroup">
                               <input id="customize-name" type="text" formControlName="customizeName"
                                 class="text-base text-color surface-overlay p-2 border-1 border-solid surface-border border-round appearance-none outline-none focus:border-primary w-full" />
                             </div>
@@ -154,6 +161,13 @@
                       </div>
                       @for (rowGroup of item.rowGroups; track $index) {
                       <div class="grid mt-3 order-items-list">
+                        <div class="col-6" [formGroup]="rowGroup">
+                          <div class="flex flex-column gap-2">
+                            <label class="font-bold">Quantity</label>
+                            <input type="number" min="1" formControlName="quantity" (blur)="calculateOrderTotalAmount()"
+                              class="text-base text-color surface-overlay p-2 border-1 border-solid surface-border border-round appearance-none outline-none focus:border-primary w-full" />
+                          </div>
+                        </div>
                         <div class="col-6" [formGroup]="rowGroup">
                           <div class="flex flex-column gap-2">
                             <label class="font-bold">Customize Name</label>

--- a/src/app/modules/order/components/create-order/create-order.component.ts
+++ b/src/app/modules/order/components/create-order/create-order.component.ts
@@ -238,18 +238,24 @@ export class CreateOrderComponent implements OnInit {
     return this.formBuilder.group({
       price: [product.price ?? null, [Validators.required]],
       rows: this.formBuilder.array(
-        isEmptyRows ? [] : [this.newOrderProductRow(product)],
+        isEmptyRows ? [] : [this.newOrderProductRow(product, {})],
         Validators.required
       ),
     });
   }
 
-  newOrderProductRow(product: ProductOrderProduct, isNew = false): FormGroup {
-    const customizeName = isNew
+  newOrderProductRow(
+    product: ProductOrderProduct,
+    options: { isBlankRow?: boolean; quantity?: number } = {},
+  ): FormGroup {
+    const isBlank = options.isBlankRow ?? false;
+    const customizeName = isBlank
       ? ''
       : (product as OrderProduct).customizeName ?? '';
-    const color = isNew ? '' : (product as OrderProduct).color ?? '';
-    const quantity = this.getOrderProductQuantity(product.name, isNew);
+    const color = isBlank ? '' : (product as OrderProduct).color ?? '';
+    const quantity =
+      options.quantity ??
+      (isBlank ? 1 : (product as OrderProduct).quantity ?? 1);
     return this.formBuilder.group({
       productId: [product.id, [Validators.required]],
       color: color,
@@ -257,7 +263,7 @@ export class CreateOrderComponent implements OnInit {
       name: product.name,
       cost: product.cost,
       weight: product.weight,
-      quantity: quantity,
+      quantity: [quantity, [Validators.required, Validators.min(1)]],
     });
   }
 
@@ -275,25 +281,37 @@ export class CreateOrderComponent implements OnInit {
     this.canShowProductDetailsTable.set(true);
   }
 
-  addOrderProductRow(product: ProductOrderProduct, isNew = false): void {
+  addOrderProductRow(
+    product: ProductOrderProduct,
+    isNewBlankRow = false,
+    explicitQuantity?: number,
+  ): void {
     const productRows = this.getOrderProductRows(product.name);
-    productRows.push(this.newOrderProductRow(product, isNew));
-    this.incrementProductQuantityCount(product.name);
+    const quantity =
+      explicitQuantity ??
+      (isNewBlankRow ? 1 : (product as OrderProduct).quantity ?? 1);
+    productRows.push(
+      this.newOrderProductRow(product, {
+        isBlankRow: isNewBlankRow,
+        quantity,
+      }),
+    );
     this.calculateOrderTotalAmount();
     this.refreshOrderProductsMap();
   }
 
   calculateOrderTotalAmount(): void {
     let total = 0;
-    Object.keys(this.orderForm.value.orderProducts).forEach(
-      (productName: string) => {
-        const orderProducts = this.orderForm.value.orderProducts[productName];
-        const orderProductQuantity = orderProducts.rows?.length;
-        if (orderProducts?.price > 0) {
-          total += orderProducts?.price * orderProductQuantity;
-        }
-      }
-    );
+    const orderProductsRoot = this.orderForm.value.orderProducts ?? {};
+    Object.keys(orderProductsRoot).forEach((productName: string) => {
+      const bundle = orderProductsRoot[productName];
+      const price = Number(bundle?.price) || 0;
+      const rows = bundle?.rows ?? [];
+      rows.forEach((row: { quantity?: number }) => {
+        const q = Math.max(1, Math.floor(Number(row.quantity) || 1));
+        total += price * q;
+      });
+    });
     this.orderTotalAmount.set(total);
   }
 
@@ -355,14 +373,20 @@ export class CreateOrderComponent implements OnInit {
   }
 
   buildCreateOrderPayload() {
+    const orderItems = this.buildOrderProductsPayload();
+    const totalUnits = orderItems.reduce(
+      (sum, row) =>
+        sum + Math.max(1, Math.floor(Number(row.quantity) || 1)),
+      0,
+    );
     return {
       description: this.orderForm.value.description,
       paymentMethod: this.orderForm.value.paymentMethod?.value,
       amount: this.orderTotalAmount(),
       customerId: this.orderForm.value.selectedCustomer?.id,
-      totalProductQuantity: this.buildOrderProductsPayload()?.length,
+      totalProductQuantity: totalUnits,
       totalWeight: this.getTotalCountByProperty('weight').toString(),
-      orderItems: this.buildOrderProductsPayload(),
+      orderItems,
       orderDate: this.orderForm.value?.orderDate,
       orderSourceIds: this.orderForm.value.selectedOrderSources,
     };
@@ -371,7 +395,6 @@ export class CreateOrderComponent implements OnInit {
   onRemoveProductRow(rowIndex: number, productName: string): void {
     const orderProductRows = this.getOrderProductRows(productName);
     orderProductRows.removeAt(rowIndex);
-    this.decrementProductQuantityCount(productName);
     this.calculateOrderTotalAmount();
     this.refreshOrderProductsMap();
   }
@@ -407,10 +430,11 @@ export class CreateOrderComponent implements OnInit {
       (value) => value.rows
     );
     const totalWeight = sumBy(orderProducts, (item) => {
-      const numericWeight = parseFloat(
-        item[propertyName].replace(/[^\d.]/g, '')
-      );
-      return isNaN(numericWeight) ? 0 : numericWeight;
+      const raw = String(item[propertyName] ?? '').replace(/[^\d.]/g, '');
+      const numericWeight = parseFloat(raw);
+      const units = Math.max(1, Math.floor(Number(item.quantity) || 1));
+      const perUnit = isNaN(numericWeight) ? 0 : numericWeight;
+      return perUnit * units;
     });
     return totalWeight;
   }
@@ -432,42 +456,11 @@ export class CreateOrderComponent implements OnInit {
     });
   }
 
-  private incrementProductQuantityCount(productName: string): void {
-    const orderProductRows = this.getOrderProductRows(productName);
-    const incrementedOrderProductQuantity =
-      Number(orderProductRows.controls[0].get('quantity')?.value) + 1;
-    for (let i = 0; i < orderProductRows.length; i++) {
-      orderProductRows.controls[i]
-        .get('quantity')
-        ?.setValue(incrementedOrderProductQuantity);
-    }
-  }
-
-  private decrementProductQuantityCount(productName: string): void {
-    const orderProductRows = this.getOrderProductRows(productName);
-    let decrementedOrderProductQuantity =
-      this.getOrderProductQuantity(productName);
-    decrementedOrderProductQuantity =
-      decrementedOrderProductQuantity > 0
-        ? decrementedOrderProductQuantity--
-        : 0;
-    for (let i = 0; i < orderProductRows.length; i++) {
-      orderProductRows.controls[i]
-        .get('quantity')
-        ?.setValue(decrementedOrderProductQuantity);
-    }
-  }
-
   protected removeProductFormGroup(productName: string): void {
     const orderProductFormGroup = this.orderForm.get(
       'orderProducts'
     ) as FormGroup;
     orderProductFormGroup.removeControl(productName);
-  }
-
-  private getOrderProductQuantity(productName: string, isNew = false): number {
-    const orderProductRows = this.getOrderProductRows(productName);
-    return isNew ? orderProductRows.length + 1 : orderProductRows?.length ?? 1;
   }
 
   private mapOrderSourcesToNameValue(

--- a/src/app/modules/order/components/edit-order/edit-order.component.ts
+++ b/src/app/modules/order/components/edit-order/edit-order.component.ts
@@ -8,6 +8,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { Order } from '../../models/order.model';
 import { OrderProduct } from '../../models/order-product.model';
 import { groupBy, uniqBy } from 'lodash-es';
+import { ProductOrderProduct } from '../../types/order-product.type';
 import { OrderSource } from 'src/app/modules/order-source/models/order-source.model';
 import { AutoCompleteModule } from 'primeng/autocomplete';
 import { DropdownModule } from 'primeng/dropdown';
@@ -121,12 +122,15 @@ export class EditOrderComponent extends CreateOrderComponent implements OnInit {
   }
 
   private populateProductRows(): void {
-    const productsGrupedByName = groupBy(this.order.products, 'name');
-    Object.keys(productsGrupedByName).forEach((orderProductKey: string) => {
-      this.order.products?.forEach((orderProduct: OrderProduct) => {
-        if (orderProduct.name === orderProductKey) {
-          this.addOrderProductRow(orderProduct as OrderProduct);
-        }
+    if (!this.order?.products?.length) return;
+    const byName = groupBy(this.order.products, 'name');
+    Object.keys(byName).forEach((productName: string) => {
+      byName[productName].forEach((orderProduct: OrderProduct) => {
+        this.addOrderProductRow(
+          orderProduct as ProductOrderProduct,
+          false,
+          orderProduct.quantity,
+        );
       });
     });
     this.canShowProductDetailsTable.set(true);

--- a/src/app/modules/order/models/order-product.model.ts
+++ b/src/app/modules/order/models/order-product.model.ts
@@ -2,6 +2,8 @@ export class OrderProduct {
   id: number;
   name: string;
   cost: number;
+  /** Unit cost captured when the line was sold (when API provides it). */
+  unitCostSnapshot?: number | null;
   price: number;
   weight: string;
   customizeName: string;
@@ -13,6 +15,7 @@ export class OrderProduct {
     this.id = orderProduct.id;
     this.name = orderProduct.name;
     this.cost = orderProduct.cost;
+    this.unitCostSnapshot = orderProduct.unitCostSnapshot;
     this.price = orderProduct.price;
     this.weight = orderProduct.weight;
     this.customizeName = orderProduct.customizeName;


### PR DESCRIPTION
## CWC-82

Fixes order UI so **totals** match **Σ (unit price × line quantity)** and each line can carry its own quantity.

### Changes
- **Create order** (v1 + v2): totals from per-row `quantity`; new rows default to **1**; removed row-count → quantity sync.
- **Edit order**: populate rows with saved quantities via `groupBy` / explicit qty.
- **v2** product card: quantity `p-inputNumber` per line; summary shows **units** and correct line totals.
- **v1** template: quantity column (desktop + mobile).
- **`OrderProduct`**: optional `unitCostSnapshot` from API.
- **Payload**: `totalProductQuantity` = sum of line units.

### Related
- Companion API PR: https://github.com/fahadsubzwari924/cwc-nest/pull/47

Made with [Cursor](https://cursor.com)