### PR TITLE
feat(reports): monthly and yearly revenue & profit plus Business Insights UX

### DIFF
--- a/.ai/agents.md
+++ b/.ai/agents.md
@@ -88,6 +88,6 @@ When operating as any implementation specialist, these rules apply **regardless 
 
 **Superpowers + Agency are on by default** via workspace rules and the Superpowers plugin—no need to ask the user to cite `.cursor-plugin` or `vendor/` paths unless setup is broken.
 
-- Follow **`routing.mdc`** (always applied) plus `.cursor/rules/workflow.mdc`, `review.mdc`, `agents.mdc` when the task matches
+- Follow **`routing.mdc`** (always applied) plus `.cursor/rules/workflow.mdc`, `review.mdc`, `agents.mdc` when the task matches; for **ship / PR**, follow **`.cursor/rules/ship-feature.mdc`** and **`AGENTS.md`** § Shipping
 - Load relevant `agency-*.mdc` when using a named Agency specialist—**including** each implementation Task/subagent during plan execution (see § Implementation plans + Superpowers subagents)
 - Keep `.cursorrules` as the index; do not duplicate `.ai/rules.md`

--- a/.ai/workflow.md
+++ b/.ai/workflow.md
@@ -11,7 +11,7 @@ For **any** work type—feature, bugfix, idea/spike, refactor, documentation, or
 3. **Plan** — ordered tasks with file paths, verification per task, and **Agency specialist per task** (use `/kickoff` or `.ai/agents.md` mapping)
 4. **Implement** — smallest vertical slice first; keep diffs reviewable. Always bind implementation workers to an **Agency specialist** per plan or `.ai/agents.md`—use `/implement` or Superpowers subagent-driven-development with Agency role prepended to each task
 5. **Review** — run `npm run lint` and `npm run test`; fix or document exceptions
-6. **Ship** — conventional commit; PR notes include risk + rollback
+6. **Ship** — follow **`.cursor/rules/ship-feature.mdc`**: resolve `$DEFAULT_BRANCH` (do not hard-code `main`/`master`); stash uncommitted work if any → checkout default → `git pull` → `feature/<slug>` or `bugfix/<slug>` → `stash pop` if applicable → conventional commit(s) → push → open PR with title + structured body (what / why / verify / risk / related PRs). Cross-repo work = one PR per repository.
 
 ## Plan execution modes
 

--- a/.cursor/rules/routing.mdc
+++ b/.cursor/rules/routing.mdc
@@ -11,6 +11,7 @@ alwaysApply: true
 - Idea or brainstorm → brainstorming + product/planning before implementation.
 - Add a feature → plan (e.g. writing-plans) then implement and verify (TDD when a harness exists).
 - Review or ship → review/verification skills plus reviewer (or security) role as fits.
+- **Open a PR / ship a feature or bugfix** → follow **`.cursor/rules/ship-feature.mdc`** end-to-end (stash if needed → default branch → pull → `feature/*` or `bugfix/*` branch → stash pop → commit → push → PR with title + body template). Bind git/PR execution to **`@agency-devops-automator.mdc`** when appropriate.
 
 ## DISPATCH RULE (non-negotiable)
 

--- a/.cursor/rules/ship-feature.mdc
+++ b/.cursor/rules/ship-feature.mdc
@@ -1,0 +1,75 @@
+---
+description: Ship feature or bugfix — create a PR using a fixed git workflow (stash, default branch, pull, topic branch, commit, push, PR). Use when the user asks to ship, open/create a PR, merge-ready handoff, or publish a branch for review.
+globs: ""
+alwaysApply: false
+---
+
+# Ship feature / bugfix (pull request)
+
+Run these steps in the **repository the user asked to ship** (this workspace or the path they name). Work that touches **both** `cvc-angular` and `nest-server` needs **one PR per repo**; cross-link PRs in the descriptions.
+
+**Execution role:** Prefer `@agency-devops-automator.mdc` or another git-capable Agency role when running commands for the user.
+
+## Before you start
+
+- Confirm **build** (and **lint** / **test** when scripts exist) pass, or document known gaps in the PR.
+- Know whether the working tree has **uncommitted** changes (stash path) or everything is already committed.
+
+## Default branch
+
+Do not assume the branch name. Resolve the integration branch, then use it everywhere below as `$DEFAULT_BRANCH`:
+
+- Prefer: `git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@'`  
+- Fallback: `main`, or `master`, or team docs.
+
+## Procedure (order matters)
+
+1. **Stash uncommitted work** (only if the tree is dirty)  
+   - Check: `git status --porcelain`  
+   - If non-empty: `git stash push -u -m "wip: before ship branch"`  
+   - If clean: skip stash; **do not** `stash pop` later.
+
+2. **Move to default branch and update**  
+   - `git fetch origin`  
+   - `git checkout $DEFAULT_BRANCH`  
+   - `git pull origin $DEFAULT_BRANCH`
+
+3. **Create a topic branch**  
+   - Feature: `git checkout -b feature/<short-kebab-slug>`  
+   - Bugfix: `git checkout -b bugfix/<short-kebab-slug>`  
+   Slug examples: `reports-grouped-multiselect`, `fix-chart-host-remount`.
+
+4. **Bring work onto the branch**  
+   - If you stashed: `git stash pop` — resolve conflicts, re-verify build/tests.  
+   - If work was already committed on another branch: **cherry-pick** or **merge** only as the user directs; otherwise commit current changes here (step 5).
+
+5. **Commit**  
+   - `git add` intentional paths only.  
+   - Message: **Conventional Commits** — `feat(scope): summary` / `fix(scope): summary` / `docs: …` / `chore: …` (present tense, no trailing period in subject line is fine).
+
+6. **Push**  
+   - `git push -u origin HEAD`
+
+7. **Open the PR**  
+   - With **GitHub CLI**: `gh pr create --base $DEFAULT_BRANCH --title "…" --body "…"`  
+   - Without `gh`: use the compare URL from `git push` output or the hosting UI.
+
+## PR title
+
+- Short, imperative, optional scope: e.g. `feat(reports): grouped report type multiselect`
+
+## PR description (use this shape)
+
+Write in full sentences.
+
+1. **What** — user-visible or API behaviour (1–3 sentences).  
+2. **Why** — problem, context, or ticket link.  
+3. **How to verify** — exact commands (`npm run build`, etc.) or QA steps.  
+4. **Risk / rollback** — blast radius; rollback = revert this PR (or note migrations / data).  
+5. **Related** — link sibling-repo PR if applicable.
+
+## Do not
+
+- Force-push to the shared default branch.  
+- Commit secrets, tokens, or production credentials.  
+- Leave a stash applied twice or forget `stash pop` after `stash push` in this flow.

--- a/.cursor/rules/workflow.mdc
+++ b/.cursor/rules/workflow.mdc
@@ -12,3 +12,4 @@ alwaysApply: false
 - TDD when harness exists: red → green → refactor; add minimal harness if missing and user agrees
 - Each plan task lists **path**, **intent**, **verification** (command or observable outcome), and **Agency role**
 - Map errors per `docs/ERROR-HANDLING.md`; API shape per `docs/API-PATTERNS.md` when touching HTTP
+- **Ship / PR:** `.cursor/rules/ship-feature.mdc` (see `.ai/workflow.md` step 6)

--- a/.cursorrules
+++ b/.cursorrules
@@ -14,7 +14,8 @@ If `vendor/` or `.cursor-plugin/` is missing, run `npx ai-dev-setup init` withou
 | File | Purpose |
 |------|---------|
 | `.ai/rules.md` | Engineering principles (SOLID, DRY, KISS, YAGNI), anti-patterns, layer rules |
-| `.ai/workflow.md` | Lifecycle, TDD, review checklist |
+| `.ai/workflow.md` | Lifecycle, TDD, review checklist, ship/PR summary (step 6) |
+| `.cursor/rules/ship-feature.mdc` | **Ship / PR:** stash → default branch → pull → feature\|bugfix branch → stash pop → commit → push → PR title & body |
 | `.ai/agents.md` | Specialist activation + quality expectations per role |
 | `docs/CONVENTIONS.md` | Stack-specific patterns: layer separation, constants, input validation |
 | `docs/API-PATTERNS.md` | HTTP layer responsibilities + validation contract — load on every API task |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,10 @@ App defaults to `http://localhost:4200/`. Point the API at your backend by editi
 - Run **`npm run build`** before considering UI work complete (catches template/type issues).
 - Match existing **ESLint** rules for the project.
 
+## Shipping (pull requests)
+
+When the user asks to **ship**, **open/create a PR**, or hand off merge-ready work, use the canonical checklist in **`.cursor/rules/ship-feature.mdc`** (also summarized in **`.ai/workflow.md`** step 6). In short: stash if dirty → checkout the repo’s **default** branch and pull → create **`feature/…`** or **`bugfix/…`** → `stash pop` if you stashed → conventional commit(s) → push → open PR with a proper **title** and **description** (what, why, verify, risk/rollback, related PRs for `nest-server`). Prefer **`@agency-devops-automator.mdc`** for executing that git/PR flow.
+
 ## References
 
 - Deploy: [`docs/DEPLOYMENT_SETUP.md`](docs/DEPLOYMENT_SETUP.md)

--- a/docs/API_CONTRACT.md
+++ b/docs/API_CONTRACT.md
@@ -22,5 +22,6 @@ This app is a **client** of the Nest API. The **authoritative** contract documen
 
 - **Login:** `POST .../auth/login` via `AuthService.signIn`; session persisted with **`token`** and **`user`** keys in `localStorage`.
 - **File uploads:** Use `httpPost` with `isFormData = true` so `Content-Type` is not forced to JSON.
+- **Reports:** `POST .../reports` supports order report types `monthly_profit` and `yearly_profit` (see `nest-server/docs/API_CONTRACT.md`). The staff UI loads definitions from `src/assets/data/report-types.json`; **`monthly_profit`** requires a selected **year** in the reports filter.
 
 Before changing response handling, read **`nest-server/docs/adr/0003-http-response-envelope-via-interceptor.md`**.

--- a/src/app/modules/dashboard/dashboard.component.html
+++ b/src/app/modules/dashboard/dashboard.component.html
@@ -27,8 +27,8 @@
   </div>
 }
 
-<div class="grid mt-5">
-  @for (report of reports(); track $index) {
+<div class="grid mt-5 dashboard-reports-grid">
+  @for (report of reports(); track report.chartId) {
     <div [ngClass]="report.cssClasses">
       <div class="card report-chart-wrapper">
         <cwc-chart-host [reportData]="report"></cwc-chart-host>

--- a/src/app/modules/dashboard/dashboard.component.scss
+++ b/src/app/modules/dashboard/dashboard.component.scss
@@ -7,6 +7,11 @@
   overflow: visible;
 }
 
+.dashboard-reports-grid {
+  column-gap: 0;
+  row-gap: 1rem;
+}
+
 /* Stats grid: use PrimeFlex's native grid layout (don't override) */
 .grid {
   width: 100%;

--- a/src/app/modules/reports/interfaces/chart-data-config.interface.ts
+++ b/src/app/modules/reports/interfaces/chart-data-config.interface.ts
@@ -1,7 +1,14 @@
+export interface ChartSeriesKeyConfig {
+  field: string;
+  name: string;
+}
+
 export interface ChartDataConfig {
   nameKey?: string;
   valueKey?: string;
   xAxisKey?: string;
   yAxisKey?: string;
   groupedDataKey?: string;
+  /** When set, build grouped bar series from these row fields. */
+  seriesKeys?: ChartSeriesKeyConfig[];
 }

--- a/src/app/modules/reports/interfaces/chart-data.interface.ts
+++ b/src/app/modules/reports/interfaces/chart-data.interface.ts
@@ -1,14 +1,14 @@
-import { DeepBarGraphData } from 'src/app/shared/interfaces';
+import {
+  BarGraphData,
+  DeepBarGraphData,
+} from 'src/app/shared/interfaces';
 
 export interface ChartSeriesData {
   name: string;
   value: number;
 }
 
-export interface BarGraphData {
-  xAxis: Array<string>;
-  yAxis: Array<number>;
-}
+export type { BarGraphData };
 
 export interface LineGraphData {
   xAxis: Array<string>;

--- a/src/app/modules/reports/models/models-registry.ts
+++ b/src/app/modules/reports/models/models-registry.ts
@@ -5,6 +5,8 @@ import {
   OrdersSummaryReport,
   OrdersDemographicsReport,
   MonthlyOrdersReport,
+  MonthlyProfitReport,
+  YearlyProfitReport,
 } from './orders';
 
 export const REPORT_MODEL_REGISTRY: { [key: string]: any } = {
@@ -14,4 +16,6 @@ export const REPORT_MODEL_REGISTRY: { [key: string]: any } = {
   order_summary: OrdersSummaryReport,
   top_performing_products: TopTenBestPerformingProductsReport,
   orders_percentage_by_source: OrdersByOrderSource,
+  monthly_profit: MonthlyProfitReport,
+  yearly_profit: YearlyProfitReport,
 };

--- a/src/app/modules/reports/models/orders/index.ts
+++ b/src/app/modules/reports/models/orders/index.ts
@@ -3,3 +3,5 @@ export * from './yearly-orders-report.model';
 export * from './order-demographics-report.model';
 export * from './orders-summary-report.model';
 export * from './orders-by-sources-report.model';
+export * from './monthly-profit-report.model';
+export * from './yearly-profit-report.model';

--- a/src/app/modules/reports/models/orders/monthly-profit-report.model.ts
+++ b/src/app/modules/reports/models/orders/monthly-profit-report.model.ts
@@ -1,0 +1,11 @@
+export class MonthlyProfitReport {
+  month: string;
+  revenue: number;
+  profit: number;
+
+  constructor(row: { month?: string; revenue?: unknown; profit?: unknown }) {
+    this.month = row?.month ?? '';
+    this.revenue = Number(row?.revenue) || 0;
+    this.profit = Number(row?.profit) || 0;
+  }
+}

--- a/src/app/modules/reports/models/orders/yearly-profit-report.model.ts
+++ b/src/app/modules/reports/models/orders/yearly-profit-report.model.ts
@@ -1,0 +1,11 @@
+export class YearlyProfitReport {
+  year: number;
+  revenue: number;
+  profit: number;
+
+  constructor(row: { year?: unknown; revenue?: unknown; profit?: unknown }) {
+    this.year = Number(row?.year) || 0;
+    this.revenue = Number(row?.revenue) || 0;
+    this.profit = Number(row?.profit) || 0;
+  }
+}

--- a/src/app/modules/reports/models/report-type-group.model.ts
+++ b/src/app/modules/reports/models/report-type-group.model.ts
@@ -1,0 +1,7 @@
+import { ReportType } from './report-type.model';
+
+/** PrimeNG MultiSelect grouped option row (optionGroupLabel + optionGroupChildren). */
+export interface ReportTypeGroupOption {
+  label: string;
+  items: ReportType[];
+}

--- a/src/app/modules/reports/reports.component.html
+++ b/src/app/modules/reports/reports.component.html
@@ -16,9 +16,10 @@
                     <div class="col-4">
                         <div class="flex flex-column gap-2">
                             <label>Select Report Type</label>
-                            <p-multiSelect [options]="reportTypes()" [(ngModel)]="selectedReportTypes" styleClass="w-full"
-                                optionLabel="name" display="chip" appendTo="body" [showClear]="true"
-                                (onChange)="onSelectReportType()" />
+                            <p-multiSelect [options]="groupedReportTypeOptions()" [(ngModel)]="selectedReportTypes"
+                                styleClass="w-full" [group]="true" optionGroupLabel="label"
+                                optionGroupChildren="items" optionLabel="name" display="chip" appendTo="body"
+                                [showClear]="true" (onChange)="onSelectReportType()" />
                         </div>
                     </div>
                     <div class="col-4">
@@ -48,9 +49,9 @@
     </div>
 </div>
 
-<div class="grid mt-5">
-  @for (report of reports(); track $index) {
-    <div [ngClass]="report.cssClasses">
+<div class="grid mt-5 reports-results-grid">
+  @for (report of reports(); track report.chartId) {
+    <div [ngClass]="report.cssClasses" class="reports-results-grid__cell">
       <div class="card report-chart-wrapper">
         <cwc-chart-host [reportData]="report"></cwc-chart-host>
       </div>

--- a/src/app/modules/reports/reports.component.scss
+++ b/src/app/modules/reports/reports.component.scss
@@ -1,0 +1,20 @@
+:host {
+  display: block;
+}
+
+.reports-results-grid {
+  align-items: flex-start;
+  /* Horizontal gap breaks two col-6 in one row (50% + 50% + gap > 100%). */
+  column-gap: 0;
+  row-gap: 1rem;
+}
+
+.reports-results-grid__cell {
+  min-width: 0;
+}
+
+.report-chart-wrapper {
+  min-height: 28rem;
+  margin-bottom: 0.25rem;
+  isolation: isolate;
+}

--- a/src/app/modules/reports/reports.component.ts
+++ b/src/app/modules/reports/reports.component.ts
@@ -3,6 +3,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ReportsService } from './services/reports.service';
 import { CustomResponse, NameValueOption } from 'src/app/shared/models';
 import { ReportType } from './models/report-type.model';
+import { ReportTypeGroupOption } from './models/report-type-group.model';
 import { INameValue } from 'src/app/shared/interfaces';
 import { ReportFilters } from './interfaces';
 import { first, last } from 'lodash-es';
@@ -46,12 +47,14 @@ export class ReportsComponent implements OnInit {
   selectedReportTypes: Array<ReportType> = [];
   selectedYear!: number;
   selectedDateRange: any;
-  reportTypes = signal<Array<ReportType>>([]);
+  /** Report types for the type MultiSelect, grouped by category (PrimeNG `group` mode). */
+  groupedReportTypeOptions = signal<Array<ReportTypeGroupOption>>([]);
   yearOptions = [
     { name: 2022, value: 2022 },
     { name: 2023, value: 2023 },
     { name: 2024, value: 2024 },
     { name: 2025, value: 2025 },
+    { name: 2026, value: 2026 },
   ];
 
   ordersDemographicsReportData: Array<INameValue> = [];
@@ -79,17 +82,70 @@ export class ReportsComponent implements OnInit {
       .getReportTypes()
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
-        next: (reportTypes: Array<ReportType>) => {
-          if (reportTypes?.length) {
-            this.reportTypes.set(
-              reportTypes.filter((reportType: ReportType) =>
-                this.selectedReportCategories.includes(reportType.category)
-              )
-            );
-          }
+        next: (allReportTypes: Array<ReportType>) => {
+          const categoryFilter = this.selectedReportCategories ?? [];
+          const filtered =
+            categoryFilter.length && allReportTypes?.length
+              ? allReportTypes.filter((rt) =>
+                  categoryFilter.includes(rt.category)
+                )
+              : [];
+
+          this.selectedReportTypes = (this.selectedReportTypes ?? []).filter(
+            (rt) => categoryFilter.includes(rt.category)
+          );
+
+          this.groupedReportTypeOptions.set(
+            this.buildGroupedReportTypeOptions(filtered, categoryFilter)
+          );
+          this.onSelectReportType();
         },
         error: (error) => console.log(error),
       });
+  }
+
+  private buildGroupedReportTypeOptions(
+    types: Array<ReportType>,
+    categoryOrder: Array<string>
+  ): Array<ReportTypeGroupOption> {
+    const meta = this.reportCategories();
+    const byCategory = new Map<string, Array<ReportType>>();
+
+    for (const t of types) {
+      const list = byCategory.get(t.category) ?? [];
+      list.push(t);
+      byCategory.set(t.category, list);
+    }
+
+    const groups: Array<ReportTypeGroupOption> = [];
+    for (const catValue of categoryOrder) {
+      const items = byCategory.get(catValue);
+      if (!items?.length) {
+        continue;
+      }
+      const label =
+        meta.find((c) => c.value === catValue)?.name ??
+        this.fallbackCategoryLabel(catValue);
+      groups.push({
+        label,
+        items: [...items].sort((a, b) =>
+          (a.name ?? a.value).localeCompare(b.name ?? b.value, undefined, {
+            sensitivity: 'base',
+          })
+        ),
+      });
+    }
+    return groups;
+  }
+
+  private fallbackCategoryLabel(categoryValue: string): string {
+    return categoryValue
+      .split(/[_\s]+/)
+      .filter(Boolean)
+      .map(
+        (w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase()
+      )
+      .join(' ');
   }
 
   onSelectReportType(): void {

--- a/src/app/modules/reports/services/report-css.service.spec.ts
+++ b/src/app/modules/reports/services/report-css.service.spec.ts
@@ -1,0 +1,72 @@
+import { ReportCssService } from './report-css.service';
+import { ReportData } from '../models/report-data.model';
+import { ChartTypes } from '../enums/chart-types.enum';
+import { ReportType } from '../models/report-type.model';
+
+function makeReportType(partial: Partial<ReportType> & { value: string }): ReportType {
+  return new ReportType({
+    name: partial.name ?? partial.value,
+    value: partial.value,
+    category: partial.category ?? 'orders',
+    title: partial.title ?? partial.value,
+    chartType: partial.chartType ?? ChartTypes.PieChart,
+    dataConfig: partial.dataConfig ?? {},
+    requiredParams: {},
+    tooltipTitle: '',
+    showLegends: false,
+  });
+}
+
+describe('ReportCssService', () => {
+  let service: ReportCssService;
+
+  beforeEach(() => {
+    service = new ReportCssService();
+  });
+
+  it('pairs two pie charts as col-6 and keeps bar chart col-12 (selection order preserved)', () => {
+    const pieA = new ReportData(
+      makeReportType({ value: 'orders_percentage_by_province' }),
+      []
+    );
+    const bar = new ReportData(
+      makeReportType({
+        value: 'monthly_orders',
+        chartType: ChartTypes.BarGraph,
+        dataConfig: { xAxisKey: 'm', yAxisKey: 'c' },
+      }),
+      []
+    );
+    const pieB = new ReportData(
+      makeReportType({ value: 'orders_percentage_by_source' }),
+      []
+    );
+
+    const input = [pieA, bar, pieB];
+    const out = service.assignCssClasses(input);
+
+    expect(out).toBe(input);
+    expect(pieA.cssClasses).toBe('col-6');
+    expect(bar.cssClasses).toBe('col-12');
+    expect(pieB.cssClasses).toBe('col-6');
+  });
+
+  it('uses full width for every report when only one pie is present among multiple reports', () => {
+    const pie = new ReportData(
+      makeReportType({ value: 'p1' }),
+      []
+    );
+    const bar = new ReportData(
+      makeReportType({
+        value: 'b1',
+        chartType: ChartTypes.BarGraph,
+        dataConfig: { xAxisKey: 'm', yAxisKey: 'c' },
+      }),
+      []
+    );
+    const input = [pie, bar];
+    service.assignCssClasses(input);
+    expect(pie.cssClasses).toBe('col-12');
+    expect(bar.cssClasses).toBe('col-12');
+  });
+});

--- a/src/app/modules/reports/services/report-css.service.ts
+++ b/src/app/modules/reports/services/report-css.service.ts
@@ -10,27 +10,56 @@ export class ReportCssService {
   private readonly HALF_WIDTH_CLASS = 'col-6';
 
   assignCssClasses(reports: Array<ReportData>): Array<ReportData> {
-    if (reports.length === 0) return reports;
+    if (reports.length === 0) {
+      return reports;
+    }
 
     if (reports.length === 1) {
       return this.assignClassToSingleReport(reports);
     }
 
     const pieChartReports = reports.filter(
-      (report) => report.chartType === 'pieChart'
+      (report) => report.chartType === ChartTypes.PieChart
     );
     const barGraphReports = reports.filter((report) =>
       [ChartTypes.BarGraph, ChartTypes.BarGraphDeep].includes(report.chartType)
     );
 
-    if (pieChartReports.length > 1) {
-      return this.assignClassesToMultiplePieCharts(
-        pieChartReports,
-        barGraphReports
+    if (pieChartReports.length >= 2) {
+      this.applyPairedPieWidths(pieChartReports);
+      barGraphReports.forEach(
+        (report) => (report.cssClasses = this.FULL_WIDTH_CLASS)
       );
+      reports.forEach((report) => {
+        if (!this.isPieChart(report) && !this.isBarChart(report)) {
+          report.cssClasses = this.FULL_WIDTH_CLASS;
+        }
+      });
+      return reports;
     }
 
     return this.assignFullWidthToAllReports(reports);
+  }
+
+  private isPieChart(report: ReportData): boolean {
+    return report.chartType === ChartTypes.PieChart;
+  }
+
+  private isBarChart(report: ReportData): boolean {
+    return [ChartTypes.BarGraph, ChartTypes.BarGraphDeep].includes(
+      report.chartType
+    );
+  }
+
+  private applyPairedPieWidths(pieChartReports: Array<ReportData>): void {
+    const isOdd = pieChartReports.length % 2 !== 0;
+    pieChartReports.forEach((report, index) => {
+      if (isOdd && index === pieChartReports.length - 1) {
+        report.cssClasses = this.FULL_WIDTH_CLASS;
+      } else {
+        report.cssClasses = this.HALF_WIDTH_CLASS;
+      }
+    });
   }
 
   private assignClassToSingleReport(
@@ -40,30 +69,12 @@ export class ReportCssService {
     return reports;
   }
 
-  private assignClassesToMultiplePieCharts(
-    pieChartReports: Array<ReportData>,
-    barGraphReports: Array<ReportData>
-  ): Array<ReportData> {
-    const isOdd = pieChartReports.length % 2 !== 0;
-    pieChartReports.forEach((report, index) => {
-      if (isOdd && index === pieChartReports.length - 1) {
-        report.cssClasses = this.FULL_WIDTH_CLASS;
-      } else {
-        report.cssClasses = this.HALF_WIDTH_CLASS;
-      }
-    });
-    barGraphReports.forEach(
-      (report) => (report.cssClasses = this.FULL_WIDTH_CLASS)
-    );
-    return [...pieChartReports, ...barGraphReports];
-  }
-
   private assignFullWidthToAllReports(
     reports: Array<ReportData>
   ): Array<ReportData> {
-    return reports.map((report) => ({
-      ...report,
-      cssClasses: this.FULL_WIDTH_CLASS,
-    }));
+    reports.forEach((report) => {
+      report.cssClasses = this.FULL_WIDTH_CLASS;
+    });
+    return reports;
   }
 }

--- a/src/app/modules/reports/services/report-data.service.ts
+++ b/src/app/modules/reports/services/report-data.service.ts
@@ -50,9 +50,19 @@ export class ReportDataService {
     data: Array<T>,
     config: ChartDataConfig
   ): BarGraphData {
-    const xAxisData: Array<string> = data.map(
-      (item) => item[config.xAxisKey as string] as string
-    );
+    const xKey = config.xAxisKey as string;
+    if (config.seriesKeys?.length) {
+      const xAxisData = data.map((item) => String(item[xKey]));
+      return {
+        xAxis: xAxisData,
+        series: config.seriesKeys.map((sk) => ({
+          name: sk.name,
+          data: data.map((item) => Number(item[sk.field]) || 0),
+        })),
+      };
+    }
+
+    const xAxisData: Array<string> = data.map((item) => String(item[xKey]));
     const yAxisData: Array<number> = data.map(
       (item) => item[config.yAxisKey as string] as number
     );

--- a/src/app/shared/components/bar-graph/bar-graph.component.ts
+++ b/src/app/shared/components/bar-graph/bar-graph.component.ts
@@ -5,6 +5,7 @@ import {
   ElementRef,
   inject,
   Input,
+  OnChanges,
   OnDestroy,
 } from '@angular/core';
 import { BarGraphData } from '../../interfaces';
@@ -21,7 +22,7 @@ type EChartsOption = echarts.EChartsOption;
   standalone: true,
   imports: [],
 })
-export class BarGraphComponent implements AfterViewInit, OnDestroy {
+export class BarGraphComponent implements AfterViewInit, OnDestroy, OnChanges {
   private readonly elementRef = inject(ElementRef);
 
   @Input() chartHeight: number = 400;
@@ -30,6 +31,7 @@ export class BarGraphComponent implements AfterViewInit, OnDestroy {
   @Input() chartId!: string;
   @Input() tooltipTitle!: string;
   @Input() chartType?: ChartTypes;
+  @Input() showLegends?: boolean;
 
   private barGraphChart!: echarts.ECharts;
   private chartInitialized: boolean = false;
@@ -39,14 +41,20 @@ export class BarGraphComponent implements AfterViewInit, OnDestroy {
   }
 
   ngOnChanges(): void {
-    if (
-      this.barGraphChart &&
-      this.data?.xAxis?.length &&
-      this.data?.yAxis?.length &&
-      this.chartInitialized
-    ) {
+    if (this.barGraphChart && this.chartInitialized && this.hasRenderableBarData()) {
       this.updateChart();
     }
+  }
+
+  private hasRenderableBarData(): boolean {
+    const xLen = this.data?.xAxis?.length ?? 0;
+    if (!xLen) {
+      return false;
+    }
+    if (this.data.series?.length) {
+      return this.data.series.every((s) => (s.data?.length ?? 0) === xLen);
+    }
+    return (this.data.yAxis?.length ?? 0) === xLen;
   }
 
   initChart(): void {
@@ -59,6 +67,7 @@ export class BarGraphComponent implements AfterViewInit, OnDestroy {
         const option: EChartsOption = this.getChartOption();
         this.barGraphChart.setOption(option);
         console.log('Bar graph chart updated successfully');
+        this.chartInitialized = true;
       } catch (error) {
         console.error('Error initializing bar graph chart:', error);
       }
@@ -80,15 +89,27 @@ export class BarGraphComponent implements AfterViewInit, OnDestroy {
     }
   }
 
-  private getChartOption(): EChartsOption {
-    const yValues = this.data?.yAxis ?? [];
-    const dataMax = yValues.length
-      ? Math.max(...yValues, 0)
-      : 0;
-    // When all values are 0, set a visible scale so the chart and axis are shown
-    const yAxisMax = dataMax === 0 ? 10 : undefined;
+  private computeYAxisMax(): number | undefined {
+    let dataMax = 0;
+    if (this.data?.series?.length) {
+      for (const s of this.data.series) {
+        for (const v of s.data ?? []) {
+          dataMax = Math.max(dataMax, Number(v) || 0);
+        }
+      }
+    } else {
+      const yValues = this.data?.yAxis ?? [];
+      dataMax = yValues.length ? Math.max(...yValues, 0) : 0;
+    }
+    return dataMax === 0 ? 10 : undefined;
+  }
 
-    return {
+  private getChartOption(): EChartsOption {
+    const yAxisMax = this.computeYAxisMax();
+    const base: Pick<
+      EChartsOption,
+      'tooltip' | 'grid' | 'xAxis' | 'yAxis'
+    > = {
       tooltip: {
         trigger: 'axis',
         axisPointer: {
@@ -111,8 +132,28 @@ export class BarGraphComponent implements AfterViewInit, OnDestroy {
       yAxis: {
         type: 'value',
         min: 0,
-        ...(yAxisMax !== undefined && { max: yAxisMax }),
+        ...(yAxisMax !== undefined ? { max: yAxisMax } : {}),
       },
+    };
+
+    if (this.data?.series?.length) {
+      const showLegend = this.showLegends !== false;
+      return {
+        ...base,
+        legend: showLegend ? { show: true, top: 0 } : { show: false },
+        series: this.data.series.map((s) => ({
+          name: s.name,
+          type: 'bar' as const,
+          data: s.data,
+          barGap: '0%',
+          barWidth: '22%',
+        })),
+      };
+    }
+
+    const yValues = this.data?.yAxis ?? [];
+    return {
+      ...base,
       series: [
         {
           name: this.tooltipTitle,

--- a/src/app/shared/components/chart-host/chart-host.component.scss
+++ b/src/app/shared/components/chart-host/chart-host.component.scss
@@ -1,10 +1,9 @@
-/* Chart host: ensure chart container is never constrained */
+/* Chart host: size to chart content; avoid height:100% collapsing rows in flex layouts */
 
 :host {
   display: block;
   width: 100%;
-  height: 100%;
-  overflow: visible;
+  min-height: 24rem;
 }
 
 ::ng-deep {
@@ -12,7 +11,6 @@
   #cwc-bar-graph-chart-container,
   .cwc-bar-graph-chart-container {
     width: 100%;
-    height: 100%;
-    overflow: visible;
+    min-height: 22rem;
   }
 }

--- a/src/app/shared/components/chart-host/chart-host.component.ts
+++ b/src/app/shared/components/chart-host/chart-host.component.ts
@@ -1,10 +1,13 @@
 import {
+  afterNextRender,
   ChangeDetectionStrategy,
   Component,
   ComponentRef,
+  effect,
   inject,
+  Injector,
   input,
-  OnInit,
+  OnDestroy,
   Type,
   ViewChild,
   ViewContainerRef,
@@ -24,22 +27,42 @@ import { DeepBarGraphComponent } from '../deep-bar-graph/deep-bar-graph.componen
   standalone: true,
   imports: [],
 })
-export class ChartHostComponent implements OnInit {
+export class ChartHostComponent implements OnDestroy {
   private readonly chartService = inject(ChartService);
   private readonly reportsDataService = inject(ReportDataService);
+  private readonly injector = inject(Injector);
 
   reportData = input.required<ReportData>();
 
   @ViewChild('chartContainer', { read: ViewContainerRef, static: true })
   chartContainer!: ViewContainerRef;
-  private componentRef: ComponentRef<any> | null = null;
 
-  ngOnInit(): void {
-    this.loadChartComponent();
+  private componentRef: ComponentRef<
+    PieChartComponent | BarGraphComponent | DeepBarGraphComponent
+  > | null = null;
+
+  constructor() {
+    afterNextRender(
+      () => {
+        effect(
+          () => {
+            const data = this.reportData();
+            this.mountChart(data);
+          },
+          { injector: this.injector }
+        );
+      },
+      { injector: this.injector }
+    );
   }
 
-  private loadChartComponent(): void {
-    const data = this.reportData();
+  private mountChart(data: ReportData): void {
+    if (!this.chartContainer) {
+      return;
+    }
+
+    this.clearChart();
+
     const chartData = this.reportsDataService.generateReportData(
       data.chartType,
       data.data,
@@ -48,23 +71,32 @@ export class ChartHostComponent implements OnInit {
     const chartComponent: Type<
       PieChartComponent | BarGraphComponent | DeepBarGraphComponent
     > = this.chartService.getChartComponent(data.chartType);
+
     this.componentRef = this.chartContainer.createComponent(chartComponent);
-    const chartId = `chart-${Math.random().toString(36).substr(2, 9)}`;
+    const chartId = `chart-${Math.random().toString(36).slice(2, 11)}`;
 
     Object.assign(this.componentRef.instance, {
       data: chartData,
       title: data?.title,
-      chartId: chartId,
+      chartId,
       subTitle: data.subTitle,
       tooltipFormat: data.tooltipFormat,
       tooltipTitle: data.tooltipTitle,
       showLegends: data.showLegends,
     });
+
+    this.componentRef.changeDetectorRef.detectChanges();
+  }
+
+  private clearChart(): void {
+    if (this.componentRef) {
+      this.componentRef.destroy();
+      this.componentRef = null;
+    }
+    this.chartContainer.clear();
   }
 
   ngOnDestroy(): void {
-    if (this.componentRef) {
-      this.componentRef.destroy();
-    }
+    this.clearChart();
   }
 }

--- a/src/app/shared/interfaces/bar-graph-data.interface.ts
+++ b/src/app/shared/interfaces/bar-graph-data.interface.ts
@@ -1,4 +1,12 @@
+export interface BarGraphSeries {
+  name: string;
+  data: number[];
+}
+
 export interface BarGraphData {
-  xAxis: Array<string>;
-  yAxis: Array<number>;
+  xAxis: string[];
+  /** Single-series charts (existing behavior). */
+  yAxis?: number[];
+  /** Multi-series grouped bars. */
+  series?: BarGraphSeries[];
 }

--- a/src/assets/data/report-types.json
+++ b/src/assets/data/report-types.json
@@ -95,6 +95,55 @@
     "tooltipTitle": "Orders Count"
   },
   {
+    "name": "Monthly Profit",
+    "value": "monthly_profit",
+    "category": "orders",
+    "title": "Monthly Revenue & Profit",
+    "subTitle": "Delivered orders only",
+    "chartType": "barGraph",
+    "dataConfig": {
+      "xAxisKey": "month",
+      "seriesKeys": [
+        { "field": "revenue", "name": "Revenue" },
+        { "field": "profit", "name": "Profit" }
+      ]
+    },
+    "dependentFields": [
+      {
+        "fieldName": "year",
+        "label": "Select Year",
+        "type": "dropdown",
+        "options": [2022, 2023, 2024, 2025, 2026]
+      }
+    ],
+    "requiredParams": {
+      "year": true
+    },
+    "tooltipTitle": "Amount",
+    "showLegends": true
+  },
+  {
+    "name": "Yearly Profit",
+    "value": "yearly_profit",
+    "category": "orders",
+    "title": "Yearly Revenue & Profit",
+    "subTitle": "Delivered orders only",
+    "chartType": "barGraph",
+    "dataConfig": {
+      "xAxisKey": "year",
+      "seriesKeys": [
+        { "field": "revenue", "name": "Revenue" },
+        { "field": "profit", "name": "Profit" }
+      ]
+    },
+    "dependentFields": [],
+    "requiredParams": {
+      "year": false
+    },
+    "tooltipTitle": "Amount",
+    "showLegends": true
+  },
+  {
     "name": "Customer Orders By Age Group",
     "value": "customer_orders_by_age_group",
     "category": "customers",


### PR DESCRIPTION
## What

Staff can see **monthly and yearly revenue and profit** for **delivered orders only** in **Business Insights**, alongside clearer report picking and more reliable charts.

## Why

Operators need period-level **revenue vs profit** (not just order volume) using the same margin logic as the dashboard, without broken layouts or stale charts when switching report types.

## How to verify

1. Point the app at an API that includes this feature’s backend (sibling PR on `cwc-nest`).
2. `npm run build`
3. **Reports:** select **Orders**, choose **Monthly Revenue & Profit** (pick a year) and **Yearly Revenue & Profit**; confirm dual-series bars and values.
4. Switch report types and **Apply** again; confirm the chart updates (no stale chart).
5. Select **two pie-style reports + one bar**; confirm two pies share a row and the bar is full width.
6. Open **Select Report Type**; confirm options are **grouped by category** (e.g. Orders, Products).

## Risk / rollback

Low UI risk; rollback by reverting this PR. No DB migrations in this repo.

## Related

- **API PR:** https://github.com/fahadsubzwari924/cwc-nest/pull/48

## Also in this PR

- Cursor **ship/PR** workflow rule (`ship-feature.mdc`) and pointers in `AGENTS.md`, `routing.mdc`, and `.ai/workflow.md` so shipping follows the same git steps each time.
